### PR TITLE
Added explicit Ubuntu version 16.04 (xenial) to base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:16.04
 MAINTAINER betaflight
 
 # If you want to tinker with this Dockerfile on your machine do as follows:


### PR DESCRIPTION
I was receiving the following error when trying to build the Docker image against the latest Ubuntu base image (18.04). I noticed the last successful builds on Docker for this was with 16.04 (xenial).

```
Err:6 http://ppa.launchpad.net/team-gcc-arm-embedded/ppa/ubuntu bionic Release
  404  Not Found [IP: 91.189.95.83 80]
Reading package lists...
E: The repository 'http://ppa.launchpad.net/team-gcc-arm-embedded/ppa/ubuntu bionic Release' does not have a Release file.
```

Revised the Dockerfile to explicitly use 16.04 which now successfully builds the Docker image.