### PR TITLE
Update Dockerfile to fix H7RF builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ MAINTAINER betaflight
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y full-upgrade
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install software-properties-common git make ccache python curl bzip2 gcc clang libblocksruntime-dev
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install software-properties-common git make ccache python curl bzip2 gcc clang libblocksruntime-dev vim-common
 RUN DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install gcc-arm-embedded


### PR DESCRIPTION
The H7RF target (and possibly others?) needs the xxd utility. This is not included in the current Docker file. I was not able to include xxd directly for some reason, but it is included as part of vim-common. 

![image](https://user-images.githubusercontent.com/22009829/137334837-c4069bdd-6e1a-490b-b853-0516202fdfc7.png)
